### PR TITLE
Fix Flaky testDeserializeWithNestedArray

### DIFF
--- a/src/test/java/net/openhft/chronicle/wire/DefaultMarshallerTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/DefaultMarshallerTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class DefaultMarshallerTest extends WireTestCommon {
 
@@ -39,10 +40,15 @@ public class DefaultMarshallerTest extends WireTestCommon {
         oc.enums[1] = NestedEnum.TWO;
         oc.enums[2] = NestedEnum.THREE;
 
-        assertEquals("!net.openhft.chronicle.wire.DefaultMarshallerTest$DMOuterClassWithEmbeddedArray {\n" +
+        String ocToString = oc.toString();
+        assertTrue(ocToString.equals("!net.openhft.chronicle.wire.DefaultMarshallerTest$DMOuterClassWithEmbeddedArray {\n" +
                 "  str: words,\n" +
                 "  enums: [ ONE, TWO, THREE ]\n" +
-                "}\n", oc.toString());
+                "}\n") ||
+                ocToString.equals("!net.openhft.chronicle.wire.DefaultMarshallerTest$DMOuterClassWithEmbeddedArray {\n" +
+                        "  enums: [ ONE, TWO, THREE ],\n" +
+                        "  str: words\n" +
+                        "}\n"));
 
         @NotNull Wire text = new TextWire(Bytes.allocateElasticOnHeap(128));
         oc.writeMarshallable(text);


### PR DESCRIPTION
The test ```DefaultMarshallerTest.testDeserializeWithNestedArray``` sometimes fails due to a different order in string comparison. From code trace, the root cause is the method ```WireMarshaller.getAllField()```, which calls on Java's reflection API [getDeclaredFields()](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--), which does not return fields in a guaranteed order. Thus, certain assertion will fail in some platforms or specific machines that adopt a different iteration order.

This PR proposes to compare 2 possible sequences during the test without changing the ```getDeclaredFields``` behaviour.