### PR TITLE
Fix Flaky addedEnum

### DIFF
--- a/src/test/java/net/openhft/chronicle/wire/dynenum/WireDynamicEnumTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/dynenum/WireDynamicEnumTest.java
@@ -13,6 +13,7 @@ import java.io.StringWriter;
 
 import static net.openhft.chronicle.wire.DynamicEnum.updateEnum;
 import static org.junit.Assert.*;
+import java.util.Arrays;
 
 public class WireDynamicEnumTest extends WireTestCommon {
     @Before
@@ -47,7 +48,7 @@ public class WireDynamicEnumTest extends WireTestCommon {
 
         nums.push2(ace);
 
-        assertEquals("push: ONE\n" +
+        String[] expected = ("push: ONE\n" +
                 "...\n" +
                 "unwraps: {\n" +
                 "  c: !WDENums {\n" +
@@ -73,7 +74,11 @@ public class WireDynamicEnumTest extends WireTestCommon {
                 "}\n" +
                 "...\n" +
                 "push2: ACE\n" +
-                "...\n", tw.toString());
+                "...\n").split("\n|,");
+        Arrays.sort(expected);
+        String[] twToString = tw.toString().split("\n|,");
+        Arrays.sort(twToString);
+        assertTrue(Arrays.toString(expected).equals(Arrays.toString(twToString)));
     }
 
     @Test


### PR DESCRIPTION
The test ```sWireDynamicEnumTest.addedEnum``` sometimes fails due to a different order in string comparison. From code trace, the root cause is the method ```WireMarshaller.getAllField()```, which calls on Java's reflection API [getDeclaredFields()](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--), which does not return fields in a guaranteed order. Thus, certain assertion will fail in some platforms or specific machines that adopt a different iteration order.

This PR proposes to sort the strings to the same order without changing the ```getDeclaredFields``` behaviour.